### PR TITLE
Updated codebase to support configurable environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ Run `ng generate component component-name` to generate a new component. You can 
 
 ## Build
 
-Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--prod` flag for a production build.
+After proper configuration of `environment.ts` and `environment.prod.ts`, run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--prod` flag for a production build.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "identity",
       "version": "0.0.0",
       "dependencies": {
         "@angular/animations": "~11.1.1",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -23,7 +23,7 @@ export class AppComponent implements OnInit {
   ngOnInit(): void {
     // We must be in an iframe OR opened with window.open
     if (!this.globalVars.inTab && !this.globalVars.inFrame()) {
-      window.location.href = `https://${this.globalVars.environment.node_hostname}`;
+      window.location.href = `https://${this.globalVars.environment.nodeHostname}`;
       return;
     }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -23,7 +23,7 @@ export class AppComponent implements OnInit {
   ngOnInit(): void {
     // We must be in an iframe OR opened with window.open
     if (!this.globalVars.inTab && !this.globalVars.inFrame()) {
-      window.location.href = 'https://bitclout.com';
+      window.location.href = `https://${this.globalVars.environment.node_hostname}`;
       return;
     }
 

--- a/src/app/backend-api.service.ts
+++ b/src/app/backend-api.service.ts
@@ -7,7 +7,7 @@ import {environment} from '../environments/environment';
   providedIn: 'root'
 })
 export class BackendAPIService {
-  endpoint = `https://${environment.node_api_hostname}`;
+  endpoint = `https://${environment.nodeApiHostname}`;
 
   constructor(
     private httpClient: HttpClient,

--- a/src/app/backend-api.service.ts
+++ b/src/app/backend-api.service.ts
@@ -1,12 +1,13 @@
 import { Injectable } from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 import {Observable} from 'rxjs';
+import {environment} from '../environments/environment';
 
 @Injectable({
   providedIn: 'root'
 })
 export class BackendAPIService {
-  endpoint = 'https://api.bitclout.com';
+  endpoint = `https://${environment.node_api_hostname}`;
 
   constructor(
     private httpClient: HttpClient,

--- a/src/app/banner/banner.component.html
+++ b/src/app/banner/banner.component.html
@@ -1,7 +1,7 @@
 <div class="identity-banner mb-30px">
   <div class="container d-flex justify-content-center align-items-center">
     <div class="mr-20px font-emoji">&#9757;</div>
-    <div>Always verify you are on identity.bitclout.com</div>
+    <div>Always verify you are on {{ globalVars.environment.hostname }}</div>
     <div class="ml-20px font-emoji">&#9757;</div>
   </div>
 </div>

--- a/src/app/banner/banner.component.ts
+++ b/src/app/banner/banner.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import {GlobalVarsService} from '../global-vars.service';
 
 @Component({
   selector: 'app-banner',
@@ -7,7 +8,7 @@ import { Component, OnInit } from '@angular/core';
 })
 export class BannerComponent implements OnInit {
 
-  constructor() { }
+  constructor(public globalVars: GlobalVarsService) { }
 
   ngOnInit(): void {
   }

--- a/src/app/global-vars.service.ts
+++ b/src/app/global-vars.service.ts
@@ -1,12 +1,13 @@
 import { Injectable } from '@angular/core';
 import {Network} from '../types/identity';
+import {environment} from '../environments/environment';
 
 @Injectable({
   providedIn: 'root'
 })
 export class GlobalVarsService {
-  static fullAccessHostnames = ['bitclout.com', 'bitclout.green'];
-  static noAccessHostnames = [''];
+  static fullAccessHostnames = environment.full_access_hostnames;
+  static noAccessHostnames = environment.no_access_hostnames;
 
   network = Network.mainnet;
   hostname = '';
@@ -26,5 +27,10 @@ export class GlobalVarsService {
       // Most browsers block access to window.top when in an iframe
       return true;
     }
+  }
+
+  // tslint:disable-next-line:typedef
+  get environment() {
+    return environment;
   }
 }

--- a/src/app/global-vars.service.ts
+++ b/src/app/global-vars.service.ts
@@ -6,8 +6,8 @@ import {environment} from '../environments/environment';
   providedIn: 'root'
 })
 export class GlobalVarsService {
-  static fullAccessHostnames = environment.full_access_hostnames;
-  static noAccessHostnames = environment.no_access_hostnames;
+  static fullAccessHostnames = environment.fullAccessHostnames;
+  static noAccessHostnames = environment.noAccessHostnames;
 
   network = Network.mainnet;
   hostname = '';

--- a/src/app/import/import.component.html
+++ b/src/app/import/import.component.html
@@ -2,11 +2,11 @@
 
 <div class="container home-container">
   <div class="fs-24px font-weight-bold">
-    bitclout.com
+    {{ globalVars.environment.node_hostname }}
   </div>
 
   <div class="fs-18px pt-15px">
-    Grant <b>bitclout.com</b> full signing privileges for these accounts:
+    Grant <b>{{ globalVars.environment.node_hostname }}</b> full signing privileges for these accounts:
   </div>
 
   <ul class="list-group pt-15px">

--- a/src/app/import/import.component.html
+++ b/src/app/import/import.component.html
@@ -2,11 +2,11 @@
 
 <div class="container home-container">
   <div class="fs-24px font-weight-bold">
-    {{ globalVars.environment.node_hostname }}
+    {{ globalVars.environment.nodeHostname }}
   </div>
 
   <div class="fs-18px pt-15px">
-    Grant <b>{{ globalVars.environment.node_hostname }}</b> full signing privileges for these accounts:
+    Grant <b>{{ globalVars.environment.nodeHostname }}</b> full signing privileges for these accounts:
   </div>
 
   <ul class="list-group pt-15px">

--- a/src/app/import/import.component.ts
+++ b/src/app/import/import.component.ts
@@ -2,6 +2,7 @@ import {Component, OnInit} from '@angular/core';
 import {AccountService} from '../account.service';
 import {IdentityService} from '../identity.service';
 import {BackendAPIService} from '../backend-api.service';
+import {GlobalVarsService} from '../global-vars.service';
 
 @Component({
   selector: 'app-import',
@@ -15,6 +16,7 @@ export class ImportComponent implements OnInit {
     private accountService: AccountService,
     private identityService: IdentityService,
     private backendApi: BackendAPIService,
+    public globalVars: GlobalVarsService
   ) { }
 
   ngOnInit(): void {

--- a/src/app/logout/logout.component.html
+++ b/src/app/logout/logout.component.html
@@ -9,7 +9,7 @@
       Logging out revokes any permissions you've granted on {{ globalVars.hostname }}.
     </p>
     <p class="pb-15px">
-      Your account will stay logged in on identity.bitclout.com.
+      Your account will stay logged in on {{ globalVars.environment.hostname }}.
     </p>
     <div class="d-flex align-items-end justify-content-end">
       <button type="button" class="btn btn-secondary mr-10px" (click)="onCancel()">Cancel</button>

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,8 @@
 export const environment = {
-  production: true
+  production: true,
+  hostname: 'identity.bitclout.com',
+  node_hostname: 'bitclout.com',
+  node_api_hostname: 'api.bitclout.com',
+  full_access_hostnames: ['bitclout.com', 'bitclout.green'],
+  no_access_hostnames: [''],
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,8 +1,8 @@
 export const environment = {
   production: true,
   hostname: 'identity.bitclout.com',
-  node_hostname: 'bitclout.com',
-  node_api_hostname: 'api.bitclout.com',
-  full_access_hostnames: ['bitclout.com', 'bitclout.green'],
-  no_access_hostnames: [''],
+  nodeHostname: 'bitclout.com',
+  nodeApiHostname: 'api.bitclout.com',
+  fullAccessHostnames: ['bitclout.com', 'bitclout.green'],
+  noAccessHostnames: [''],
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,7 +3,12 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  hostname: 'identity.bitclout.com',
+  node_hostname: 'bitclout.com',
+  node_api_hostname: 'api.bitclout.com',
+  full_access_hostnames: ['bitclout.com', 'bitclout.green'],
+  no_access_hostnames: [''],
 };
 
 /*

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -5,10 +5,10 @@
 export const environment = {
   production: false,
   hostname: 'identity.bitclout.com',
-  node_hostname: 'bitclout.com',
-  node_api_hostname: 'api.bitclout.com',
-  full_access_hostnames: ['bitclout.com', 'bitclout.green'],
-  no_access_hostnames: [''],
+  nodeHostname: 'bitclout.com',
+  nodeApiHostname: 'api.bitclout.com',
+  fullAccessHostnames: ['bitclout.com', 'bitclout.green'],
+  noAccessHostnames: [''],
 };
 
 /*


### PR DESCRIPTION
I've replaced the hardcoded `bitclout.com` references with `environment.ts` and `environment.prod.ts`. 
By doing this, both the developers and people who want to run an instance of identity for themselves can swap in the variables and quickly build the project. 