### PR TITLE
Update accessLevelRequest to support numeric value

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -43,7 +43,12 @@ export class AppComponent implements OnInit {
       }
 
       if (params.accessLevelRequest) {
-        this.globalVars.accessLevelRequest = params.accessLevelRequest;
+        if (!isNaN(params.accessLevelRequest)) {
+          this.globalVars.accessLevelRequest = parseInt(params.accessLevelRequest);
+        }
+        else {
+          this.globalVars.accessLevelRequest = params.accessLevelRequest;
+        }
       }
     });
   }


### PR DESCRIPTION
"Long" time user, first time contributor 😉

Currently, neither the string values or the int values for `accessLevelRequest` work fully for logging in.

## Int value → Disabled login button
Passing the int (e.g. `?accessLevelRequest=3`) stores it as the string "3" which then fails the UI component checks that are used to enable the login button because `Object.values(AccessLevel)` contains the int values of the enum, and the string values of the enum names, but not the integer values in string form. https://github.com/bitclout/identity/blob/5b0a4ed22982e8c57b660661de7d80a37ebe49c7/src/app/log-in/log-in.component.ts#L78

## String value → UI bug
Passing the String value (e.g. `?accessLevelRequest=ApproveLarge`) causes the UI to not update correctly because the `>=` comparison on the string value of the enum returns false. https://github.com/bitclout/identity/blob/9ff62bade3608b22736ca1c1a919505693095e09/src/app/log-in/log-in.component.html#L78

Not sure if this is a fully idiomatic JS solution, but I wanted to propose a solution rather than just raise an issue 😊