### PR TITLE
Add support for viewing in a mobile webview

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -21,12 +21,6 @@ export class AppComponent implements OnInit {
   ) { }
 
   ngOnInit(): void {
-    // We must be in an iframe OR opened with window.open
-    if (!this.globalVars.inTab && !this.globalVars.inFrame()) {
-      window.location.href = `https://${this.globalVars.environment.nodeHostname}`;
-      return;
-    }
-
     this.identityService.initialize().subscribe(res => {
       this.globalVars.hostname = res.hostname;
       if (this.globalVars.isFullAccessHostname()) {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -21,17 +21,13 @@ export class AppComponent implements OnInit {
   ) { }
 
   ngOnInit(): void {
-    this.identityService.initialize().subscribe(res => {
-      this.globalVars.hostname = res.hostname;
-      if (this.globalVars.isFullAccessHostname()) {
-        this.globalVars.accessLevelRequest = AccessLevel.Full;
-      }
-
-      this.loading = false;
-    });
-
-    // Store testnet for duration of this session
     this.activatedRoute.queryParams.subscribe(params => {
+      // We must be in an iframe OR opened with window.open OR running in a webview
+      if (!params.webview && !this.globalVars.inTab && !this.globalVars.inFrame()) {
+        window.location.href = `https://${this.globalVars.environment.nodeHostname}`;
+        return;
+      }
+      // Store testnet for duration of this session
       if (params.testnet) {
         this.globalVars.network = Network.testnet;
       }
@@ -39,6 +35,15 @@ export class AppComponent implements OnInit {
       if (params.accessLevelRequest) {
         this.globalVars.accessLevelRequest = parseInt(params.accessLevelRequest, 10);
       }
+    });
+
+    this.identityService.initialize().subscribe(res => {
+      this.globalVars.hostname = res.hostname;
+      if (this.globalVars.isFullAccessHostname()) {
+        this.globalVars.accessLevelRequest = AccessLevel.Full;
+      }
+
+      this.loading = false;
     });
   }
 }

--- a/src/app/global-vars.service.ts
+++ b/src/app/global-vars.service.ts
@@ -13,8 +13,6 @@ export class GlobalVarsService {
   hostname = '';
   accessLevelRequest = AccessLevel.ApproveAll;
 
-  inTab = !!window.opener;
-
   constructor() { }
 
   isFullAccessHostname(): boolean {

--- a/src/app/global-vars.service.ts
+++ b/src/app/global-vars.service.ts
@@ -13,6 +13,8 @@ export class GlobalVarsService {
   hostname = '';
   accessLevelRequest = AccessLevel.ApproveAll;
 
+  inTab = !!window.opener;
+
   constructor() { }
 
   isFullAccessHostname(): boolean {

--- a/src/app/identity.service.ts
+++ b/src/app/identity.service.ts
@@ -290,12 +290,12 @@ export class IdentityService {
 
   // Post message to correct client
   private postMessage(message: any): void {
-    // iOS Webview with registered "appInterface" handler
-    if (this.currentWindow.webkit?.messageHandlers?.appInterface !== undefined) {
-      this.currentWindow.webkit.messageHandlers.appInterface.postMessage(message, '*');
-      // Android Webview with registered "appInterface" handler
-    } else if (this.currentWindow.appInterface !== undefined) {
-      this.currentWindow.appInterface.postMessage(JSON.stringify(message), '*');
+    // iOS Webview with registered "bitcloutIdentityAppInterface" handler
+    if (this.currentWindow.webkit?.messageHandlers?.bitcloutIdentityAppInterface !== undefined) {
+      this.currentWindow.webkit.messageHandlers.bitcloutIdentityAppInterface.postMessage(message, '*');
+      // Android Webview with registered "bitcloutIdentityAppInterface" handler
+    } else if (this.currentWindow.bitcloutIdentityAppInterface !== undefined) {
+      this.currentWindow.bitcloutIdentityAppInterface.postMessage(JSON.stringify(message), '*');
       // Web
     } else {
       this.currentWindow.postMessage(message, '*');

--- a/src/app/log-in/log-in.component.html
+++ b/src/app/log-in/log-in.component.html
@@ -1,6 +1,6 @@
 <app-banner></app-banner>
 
-<div class="container home-container" *ngIf="globalVars.inTab">
+<div class="container home-container">
   <div *ngIf="showLoadAccount" class="mb-30px">
     <div class="fs-24px font-weight-bold">
       Load your account

--- a/src/app/sign-up/sign-up.component.html
+++ b/src/app/sign-up/sign-up.component.html
@@ -1,6 +1,6 @@
 <app-banner></app-banner>
 
-<div class="container home-container" *ngIf="globalVars.inTab">
+<div class="container home-container">
   <!-- Step 1 -->
   <div *ngIf="stepNum == 1">
     <div class="fs-15px fc-muted">STEP 1 of 4</div>


### PR DESCRIPTION
Currently, Identity posts messages to either it's parent window or it's opener. For mobile apps that want to launch Identity in a Webview there is no way to access and respond to the messages.

To address this, I added a private function in the identity service which posts messages to the correct location. 
If an iOS or Android device registers a message handler called "appInterface" then they will be sent to that handler otherwise it will fall back to the current behaviour of using this.currentWindow which will be the opener or parent.

The checks to ensure Identity is run in either a tab or an iframe have been removed as neither is the case when a mobile webview directly accesses Identity.

Below is how it can be used, these details should be added to https://docs.bitclout.com/devs/identity-api

**Android**
An Android app can use Identity to carry out the log in flow like so:

```
webview.settings.javaScriptEnabled = true
webview.settings.domStorageEnabled = true
webview.addJavascriptInterface(MyHandler(), "bitcloutIdentityAppInterface")
webview.loadUrl("identity.bitclout.com/log-in")
```

```
class MyHandler() {
   @JavascriptInterface
   fun postMessage(data: String, transferList: String): Boolean {
      // Handle received messages
      return true
   }
}
```

Messages can be sent back to Identity with:

`webview.evaluateJavascript("window.postMessage({service: 'identity',id: 'id'})", null)`

**iOS**
An iOS app can use Identity to carry out the log in flow like so:

```
let messageHandler = MyHandler() 
let config = WKWebViewConfiguration()
config.userContentController.add(messageHandler, name: "bitcloutIdentityAppInterface")
let view = WKWebView(frame: .zero, configuration: config)
```

```
extension MyHandler: WKScriptMessageHandler {
    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
        // Handle received messages
    }
}
```

Messages can be sent back to Identity with:

`webview.evaluateJavaScript("window.postMessage({service: 'identity',id: 'id'})")`