### PR TITLE
Fix mobile webviews as query params weren't being applied 

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,7 +3,6 @@ import {ActivatedRoute} from '@angular/router';
 import {GlobalVarsService} from './global-vars.service';
 import {IdentityService} from './identity.service';
 import {AccessLevel, Network} from '../types/identity';
-import {skip} from 'rxjs/operators';
 
 @Component({
   selector: 'app-root',
@@ -22,8 +21,7 @@ export class AppComponent implements OnInit {
   ) { }
 
   ngOnInit(): void {
-    // The first emission of queryParams is always empty as it starts with an empty BehaviourSubject
-    this.activatedRoute.queryParams.pipe(skip(1)).subscribe(params => {
+    this.activatedRoute.queryParams.subscribe(params => {
       // Store various parameters for duration of this session
       if (params.webview) {
         this.globalVars.webview = true;

--- a/src/app/identity.service.ts
+++ b/src/app/identity.service.ts
@@ -290,14 +290,12 @@ export class IdentityService {
 
   // Post message to correct client
   private postMessage(message: any): void {
-    if (this.globalVars.webview) {
-      if (this.currentWindow.webkit?.messageHandlers?.bitcloutIdentityAppInterface !== undefined) {
-        // iOS Webview with registered "bitcloutIdentityAppInterface" handler
-        this.currentWindow.webkit.messageHandlers.bitcloutIdentityAppInterface.postMessage(message, '*');
-      } else if (this.currentWindow.bitcloutIdentityAppInterface !== undefined) {
-        // Android Webview with registered "bitcloutIdentityAppInterface" handler
-        this.currentWindow.bitcloutIdentityAppInterface.postMessage(JSON.stringify(message), '*');
-      }
+    if (this.currentWindow.webkit?.messageHandlers?.bitcloutIdentityAppInterface !== undefined) {
+      // iOS Webview with registered "bitcloutIdentityAppInterface" handler
+      this.currentWindow.webkit.messageHandlers.bitcloutIdentityAppInterface.postMessage(message, '*');
+    } else if (this.currentWindow.bitcloutIdentityAppInterface !== undefined) {
+      // Android Webview with registered "bitcloutIdentityAppInterface" handler
+      this.currentWindow.bitcloutIdentityAppInterface.postMessage(JSON.stringify(message), '*');
     } else {
       this.currentWindow.postMessage(message, '*');
     }


### PR DESCRIPTION
After the previous PR some changes were made to make more use of the webview query param to disable the banner and add an extra check to the message posting. Unfortunately this broke things as the initialize event was sent out immediately before the query params have come through, so the identity service thinks its not running in a webview and posts the message to the standard window. I've removed that check as the presence of a "bitcloutIdentityAppInterface" is enough to be sure that the loader of this page has opted in to having the message sent outside of the usual window.

The other issue was due to the ordering of the initial calls in app.component so I've rearranged them to set the globalVars first before checking the redirect as this was checking for webview in globalVars before it was set

Closes #4