### PR TITLE
Fixed approve message for BasicTransfer Transactions

### DIFF
--- a/src/app/approve/approve.component.ts
+++ b/src/app/approve/approve.component.ts
@@ -82,7 +82,9 @@ export class ApproveComponent implements OnInit {
         let sendKey = 'unknown';
         let sendAmount = 'unknown';
         for (const output of this.transaction.outputs) {
-          if (output.publicKey !== this.transaction.publicKey) {
+          if (
+            !this.equalUInt8Arrays(output.publicKey, this.transaction.publicKey)
+          ) {
             sendKey = this.base58KeyCheck(output.publicKey);
             sendAmount = `${output.amountNanos / 1e9}`;
           }
@@ -157,5 +159,23 @@ export class ApproveComponent implements OnInit {
   base58KeyCheck(keyBytes: Uint8Array): string {
     const prefix = CryptoService.PUBLIC_KEY_PREFIXES[this.globalVars.network].bitclout;
     return bs58check.encode(Buffer.from([...prefix, ...keyBytes]));
+  }
+  
+  
+  //obtained from https://stackoverflow.com/a/52181275
+  equalUInt8Arrays(a: Uint8Array, b: Uint8Array): Boolean {
+    if (a instanceof ArrayBuffer) a = new Uint8Array(a, 0);
+    if (b instanceof ArrayBuffer) b = new Uint8Array(b, 0);
+
+    if (a.byteLength != b.byteLength) return false;
+
+    const ua = new Uint8Array(a.buffer, a.byteOffset, a.byteLength);
+    const ub = new Uint8Array(b.buffer, b.byteOffset, b.byteLength);
+
+    for (let i = ua.length; -1 < i; i -= 1) {
+      if (ua[i] !== ub[i]) return false;
+    }
+
+    return true;
   }
 }


### PR DESCRIPTION
What I changed in the code: Previously, the if statement in generateTransactionDescription() -> switch -> case TransactionMetadataBasicTransfer was always evaluating to true because === compares reference and not equality. They are different objects, so if statement always evaluated to true. It is now changed to check for equality of publicKeys. 

Issue: Approve message for window.open("https://identity.bitclout.com/approve?tx=abc123....") is all wrong for basic transactions of sending bitclout.

At the file identity/src/app/approve/approve.component.ts in generateTransactionDescription(), when the case is a TransactionMetadataBasicTransfer, the display message is all wrong.

It shows total amount of nanos in the transaction including ChangeAmountNanos which is misleading. It should only be SpendAmountNanos.
The public key displayed is the sender's whereas it should be the recipients
When I use the /v0/send-bitclout api route to send 0.1 bitclout worth in nanos from BC1YLiXsLZvrySthVJPJozLr3rMSo2BARZ4VG525bhbsAJCTvwJQJCe to BC1YLh4R1ewSLphyWncnUsRmJ5okAn4xjRMUHD5Q6vVd5ZAYgf8zWZo, I get the following message:

localhost wants to send 0.203897603 bitclout to BC1YLiXsLZvrySthVJPJozLr3rMSo2BARZ4VG525bhbsAJCTvwJQJCe