### PR TITLE
Display a message when sending to yourself

### DIFF
--- a/src/app/approve/approve.component.ts
+++ b/src/app/approve/approve.component.ts
@@ -80,15 +80,26 @@ export class ApproveComponent implements OnInit {
     switch (this.transaction.metadata.constructor) {
       case TransactionMetadataBasicTransfer:
         const outputs = [];
+        
+        let sendingToSelf = true; //for if sender and recipient are same account
+        
         for (const output of this.transaction.outputs) {
           // Skip the change output. 0 means the buffers are equal
           if (Buffer.compare(output.publicKey, this.transaction.publicKey) !== 0) {
+            sendingToSelf = false;
             const sendKey = this.base58KeyCheck(output.publicKey);
             const sendAmount = `${output.amountNanos / 1e9}`;
             outputs.push(`${sendAmount} CLOUT to ${sendKey}`);
           }
         }
+        
+        //if all recipients are same as this.transaction.publicKey (outputs is empty)
+        if (sendingToSelf && this.transaction.outputs.length > 0) {
+          outputs.push(`$CLOUT to ${this.transaction.publicKey}`);
+        }
+        
         description = `send ${outputs.join(', ')}`;
+         
         break;
 
       case TransactionMetadataBitcoinExchange:


### PR DESCRIPTION
Previously displayed a blank message for a basic transfer txn (i.e. whole message was just "localhost wants to send") when sender and recipient were the same.

Now displays "localhost wants to send $CLOUT to public key".