### PR TITLE
Support Sign-In w/ Google Webview

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -44,7 +44,7 @@ export class AppComponent implements OnInit {
       this.globalVars.webview = true;
     }
 
-    if (params.get('testnet')) {
+    if (params.get('testnet') || stateParamsFromGoogle.testnet) {
       this.globalVars.network = Network.testnet;
     }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,6 +3,7 @@ import {ActivatedRoute} from '@angular/router';
 import {GlobalVarsService} from './global-vars.service';
 import {IdentityService} from './identity.service';
 import {AccessLevel, Network} from '../types/identity';
+import {getStateParamsFromGoogle} from './auth/google/google.component';
 
 @Component({
   selector: 'app-root',
@@ -23,13 +24,23 @@ export class AppComponent implements OnInit {
   ngOnInit(): void {
     // load params
     const params = new URLSearchParams(window.location.search);
+
+    // grab hash parameters from window and not activatedRoute because init is run before detecting fragment
+    let hashParams;
+    if (window.location.hash && window.location.hash.length > 1){
+      // hash includes the hashtag symbol so use substring to remove it
+      hashParams = new URLSearchParams(window.location.hash.substring(1));
+    }
+
     const accessLevelRequest = params.get('accessLevelRequest');
 
     if (accessLevelRequest) {
       this.globalVars.accessLevelRequest = parseInt(accessLevelRequest, 10);
     }
 
-    if (params.get('webview')) {
+
+    const stateParamsFromGoogle = getStateParamsFromGoogle(hashParams);
+    if (params.get('webview') || stateParamsFromGoogle.webview) {
       this.globalVars.webview = true;
     }
 

--- a/src/app/auth/google/google.component.ts
+++ b/src/app/auth/google/google.component.ts
@@ -141,11 +141,15 @@ export class GoogleComponent implements OnInit {
 }
 
 export const getStateParamsFromGoogle = (hashParams?: URLSearchParams): GoogleAuthState => {
-  const defaultStateParams = { webview: false };
-  const stateParamsString = hashParams?.get('state');
-  const stateParams: GoogleAuthState = stateParamsString ? JSON.parse(atob(stateParamsString)) : null;
-  if (stateParams) {
-    return stateParams;
+  const defaultStateParams = { webview: false, testnet: false };
+  try {
+    const stateParamsString = hashParams?.get('state');
+    const stateParams: GoogleAuthState = stateParamsString ? JSON.parse(atob(stateParamsString)) : null;
+    if (stateParams) {
+      return stateParams;
+    }
+  } catch (e) {
+    console.error('Failed to parse state passed from Google');
   }
   return defaultStateParams;
 };

--- a/src/app/auth/google/google.component.ts
+++ b/src/app/auth/google/google.component.ts
@@ -8,7 +8,8 @@ import {EntropyService} from '../../entropy.service';
 import {GoogleDriveService} from '../../google-drive.service';
 import {GlobalVarsService} from '../../global-vars.service';
 import {ActivatedRoute, Router} from '@angular/router';
-import {TextService} from "../../text.service";
+import {TextService} from '../../text.service';
+import {GoogleAuthState} from '../../../types/identity';
 
 @Component({
   selector: 'app-google',
@@ -138,3 +139,13 @@ export class GoogleComponent implements OnInit {
     return `${this.globalVars.network}.json`;
   }
 }
+
+export const getStateParamsFromGoogle = (hashParams?: URLSearchParams): GoogleAuthState => {
+  const defaultStateParams = { webview: false };
+  const stateParamsString = hashParams?.get('state');
+  const stateParams: GoogleAuthState = stateParamsString ? JSON.parse(atob(stateParamsString)) : null;
+  if (stateParams) {
+    return stateParams;
+  }
+  return defaultStateParams;
+};

--- a/src/app/log-in/log-in.component.ts
+++ b/src/app/log-in/log-in.component.ts
@@ -69,9 +69,13 @@ export class LogInComponent implements OnInit {
     oauthUri.searchParams.append('client_id', GoogleDriveService.CLIENT_ID);
     oauthUri.searchParams.append('scope', GoogleDriveService.DRIVE_SCOPE);
     oauthUri.searchParams.append('response_type', 'token');
+    // TODO: Investigate using this parameter to defend against CSRF attacks
     // pass on webview state to Google OAuth state
     // https://stackoverflow.com/questions/7722062/google-oauth-2-0-redirect-uri-with-several-parameters
-    const stateString = btoa(JSON.stringify({webview: this.globalVars.webview}));
+    const stateString = btoa(JSON.stringify({
+      webview: this.globalVars.webview,
+      testnet: this.globalVars.network === Network.testnet
+    }));
     oauthUri.searchParams.append('state', stateString);
 
     window.location.href = oauthUri.toString();

--- a/src/app/log-in/log-in.component.ts
+++ b/src/app/log-in/log-in.component.ts
@@ -7,7 +7,7 @@ import {Network} from '../../types/identity';
 import {CryptoService} from '../crypto.service';
 import {EntropyService} from '../entropy.service';
 import {GoogleDriveService} from '../google-drive.service';
-import {RouteNames} from "../app-routing.module";
+import {RouteNames} from '../app-routing.module';
 
 @Component({
   selector: 'app-log-in',
@@ -69,6 +69,10 @@ export class LogInComponent implements OnInit {
     oauthUri.searchParams.append('client_id', GoogleDriveService.CLIENT_ID);
     oauthUri.searchParams.append('scope', GoogleDriveService.DRIVE_SCOPE);
     oauthUri.searchParams.append('response_type', 'token');
+    // pass on webview state to Google OAuth state
+    // https://stackoverflow.com/questions/7722062/google-oauth-2-0-redirect-uri-with-several-parameters
+    const stateString = btoa(JSON.stringify({webview: this.globalVars.webview}));
+    oauthUri.searchParams.append('state', stateString);
 
     window.location.href = oauthUri.toString();
   }

--- a/src/types/identity.ts
+++ b/src/types/identity.ts
@@ -37,3 +37,7 @@ export enum AccessLevel {
   // Node can sign all transactions without approval
   Full = 4,
 }
+
+export interface GoogleAuthState {
+  webview: boolean;
+}

--- a/src/types/identity.ts
+++ b/src/types/identity.ts
@@ -39,5 +39,6 @@ export enum AccessLevel {
 }
 
 export interface GoogleAuthState {
+  testnet: boolean;
   webview: boolean;
 }


### PR DESCRIPTION
Today, Bitclout Identity doesn't support sign-in with Google from a WebView. This is because the OAuth callback from Google doesn't carry-over the `webview=true` parameter from the original Identity context.

This PR uses Google's "state" query parameter to properly send the context back to Bitclout Identity and inform it that the login attempt came from a WebView so it can initialize correctly.