### PR TITLE
Add shared secret encryption/decryption

### DIFF
--- a/src/app/crypto.service.ts
+++ b/src/app/crypto.service.ts
@@ -136,6 +136,21 @@ export class CryptoService {
     return bs58check.encode(prefixAndKey);
   }
 
+  // Decode public key base58check to Buffer of secp256k1 public key
+  publicKeyBase58CheckToECBuffer(publicKeyBase58Check: string): Buffer {
+    // Sanity check similar to Base58CheckDecodePrefix from core/lib/base58.go
+    if (publicKeyBase58Check.length < 5){
+      throw new Error('Failed to decode public key');
+    }
+    const decoded = bs58check.decode(publicKeyBase58Check);
+    const payload = Uint8Array.from(decoded).slice(3);
+
+    const ec = new EC('secp256k1');
+    const publicKey = ec.keyFromPublic(payload, 'array');
+
+    return new Buffer(publicKey.getPublic('array'));
+  }
+
   keychainToBtcAddress(keychain: HDNode, network: Network): string {
     const prefix = CryptoService.PUBLIC_KEY_PREFIXES[network].bitcoin;
     // @ts-ignore TODO: add "identifier" to type definition

--- a/src/app/crypto.service.ts
+++ b/src/app/crypto.service.ts
@@ -137,18 +137,18 @@ export class CryptoService {
   }
 
   // Decode public key base58check to Buffer of secp256k1 public key
-  publicKeyBase58CheckToECBuffer(publicKeyBase58Check: string): Buffer {
+  publicKeyToECBuffer(publicKey: string): Buffer {
     // Sanity check similar to Base58CheckDecodePrefix from core/lib/base58.go
-    if (publicKeyBase58Check.length < 5){
+    if (publicKey.length < 5){
       throw new Error('Failed to decode public key');
     }
-    const decoded = bs58check.decode(publicKeyBase58Check);
+    const decoded = bs58check.decode(publicKey);
     const payload = Uint8Array.from(decoded).slice(3);
 
     const ec = new EC('secp256k1');
-    const publicKey = ec.keyFromPublic(payload, 'array');
+    const publicKeyEC = ec.keyFromPublic(payload, 'array');
 
-    return new Buffer(publicKey.getPublic('array'));
+    return new Buffer(publicKeyEC.getPublic('array'));
   }
 
   keychainToBtcAddress(keychain: HDNode, network: Network): string {

--- a/src/app/identity.service.ts
+++ b/src/app/identity.service.ts
@@ -117,9 +117,17 @@ export class IdentityService {
       return;
     }
 
-    const { id, payload: { encryptedSeedHex, encryptedHexesAndPublicKeys } } = data;
-    const seedHex = this.cryptoService.decryptSeedHex(encryptedSeedHex, this.globalVars.hostname);
-    const decryptedHexes = this.signingService.decryptMessages(seedHex, encryptedHexesAndPublicKeys);
+    const seedHex = this.cryptoService.decryptSeedHex(data.payload.encryptedSeedHex, this.globalVars.hostname);
+    const id = data.id;
+
+    let decryptedHexes;
+    if (data.payload.encryptedHexes){
+      const encryptedHexes = data.payload.encryptedHexes;
+      decryptedHexes = this.signingService.decryptMessages(seedHex, encryptedHexes);
+    } else {
+      const encryptedHexesAndPublicKeys = data.payload.encryptedHexesAndPublicKeys;
+      decryptedHexes = this.signingService.decryptMessages(seedHex, encryptedHexesAndPublicKeys);
+    }
 
     this.respond(id, {
       decryptedHexes

--- a/src/app/identity.service.ts
+++ b/src/app/identity.service.ts
@@ -104,9 +104,9 @@ export class IdentityService {
       return;
     }
 
-    const { id, payload: { encryptedSeedHex, recipientPubkey, message} } = data;
+    const { id, payload: { encryptedSeedHex, recipientPublicKey, message} } = data;
     const seedHex = this.cryptoService.decryptSeedHex(encryptedSeedHex, this.globalVars.hostname);
-    const encryptedMessage = this.signingService.encryptMessage(seedHex, recipientPubkey, message);
+    const encryptedMessage = this.signingService.encryptMessage(seedHex, recipientPublicKey, message);
     this.respond(id, {
       encryptedMessage
     });
@@ -122,11 +122,13 @@ export class IdentityService {
 
     let decryptedHexes;
     if (data.payload.encryptedHexes){
+      // Legacy public key decryption
       const encryptedHexes = data.payload.encryptedHexes;
-      decryptedHexes = this.signingService.decryptMessages(seedHex, encryptedHexes);
+      decryptedHexes = this.signingService.decryptMessagesLegacy(seedHex, encryptedHexes);
     } else {
-      const encryptedHexesAndPublicKeys = data.payload.encryptedHexesAndPublicKeys;
-      decryptedHexes = this.signingService.decryptMessages(seedHex, encryptedHexesAndPublicKeys);
+      // Shared secret decryption
+      const encryptedMessages = data.payload.encryptedMessages;
+      decryptedHexes = this.signingService.decryptMessages(seedHex, encryptedMessages);
     }
 
     this.respond(id, {

--- a/src/app/signing.service.ts
+++ b/src/app/signing.service.ts
@@ -61,7 +61,8 @@ export class SigningService {
         // sent it to determine if message is decryptable
         try {
           if (!encryptedHexAndPublicKey.IsSender) {
-            decryptedHexes[encryptedHex] = ecies.decryptLegacy(privateKeyBuffer, encryptedBytes).toString();
+            const opts = {legacy: true};
+            decryptedHexes[encryptedHex] = ecies.decrypt(privateKeyBuffer, encryptedBytes, opts).toString();
           } else {
             decryptedHexes[encryptedHex] = '';
           }

--- a/src/lib/ecies/index.js
+++ b/src/lib/ecies/index.js
@@ -192,5 +192,3 @@ export const decryptShared = function(privateKeyRecipient, publicKeySender, encr
   opts.legacy = false;
   return decrypt(sharedPrivateKey, encrypted, opts);
 }
-
-// @petern was here

--- a/src/lib/ecies/index.js
+++ b/src/lib/ecies/index.js
@@ -36,13 +36,27 @@ export const kdf = function(secret, outputLength) {
 
 // AES-128-CTR is used in the Parity implementation
 // Get the AES-128-CTR browser implementation
-
 const aesCtrEncrypt = function(counter, key, data) {
+  const cipher = createCipheriv('aes-128-ctr', key, counter);
+  const firstChunk = cipher.update(data);
+  const secondChunk = cipher.final();
+  return Buffer.concat([firstChunk, secondChunk]);
+}
+
+const aesCtrDecrypt = function(counter, key, data) {
+  const cipher = createDecipheriv('aes-128-ctr', key, counter);
+  const firstChunk = cipher.update(data);
+  const secondChunk = cipher.final();
+  return Buffer.concat([firstChunk, secondChunk]);
+}
+
+// Legacy AES-128-CTR without second chunk
+const aesCtrEncryptLegacy = function(counter, key, data) {
   const cipher = createCipheriv('aes-128-ctr', key, counter);
   return cipher.update(data).toString();
 }
 
-const aesCtrDecrypt = function(counter, key, data) {
+const aesCtrDecryptLegacy = function(counter, key, data) {
   const cipher = createDecipheriv('aes-128-ctr', key, counter);
   return cipher.update(data).toString();
 }
@@ -143,3 +157,74 @@ export const decrypt = function(privateKey, encrypted) {
   // decrypt message
   return aesCtrDecrypt(iv, encryptionKey, ciphertext);
 };
+
+// Encrypt AES-128-CTR and serialise as in Parity
+// Serialization: <ephemPubKey><IV><CipherText><HMAC>
+export const encryptLegacy = function(publicKeyTo, msg, opts) {
+  opts = opts || {};
+  const ephemPrivateKey = opts.ephemPrivateKey || randomBytes(32);
+  const ephemPublicKey = getPublic(ephemPrivateKey);
+
+  const sharedPx = derive(ephemPrivateKey, publicKeyTo);
+  const hash = kdf(sharedPx, 32);
+  const iv = opts.iv || randomBytes(16);
+  const encryptionKey = hash.slice(0, 16);
+
+  // Generate hmac
+  const macKey = createHash("sha256").update(hash.slice(16)).digest();
+  const ciphertext = aesCtrEncryptLegacy(iv, encryptionKey, msg);
+  const dataToMac = Buffer.from([...iv, ...ciphertext]);
+  const HMAC = hmacSha256Sign(macKey, dataToMac);
+
+  return Buffer.from([...ephemPublicKey, ...iv, ...ciphertext, ...HMAC]);
+};
+
+// Decrypt serialised AES-128-CTR
+export const decryptLegacy = function(privateKey, encrypted) {
+  const metaLength = 1 + 64 + 16 + 32;
+  assert(encrypted.length > metaLength, "Invalid Ciphertext. Data is too small")
+  assert(encrypted[0] >= 2 && encrypted[0] <= 4, "Not valid ciphertext.")
+
+  // deserialize
+  const ephemPublicKey = encrypted.slice(0, 65);
+  const cipherTextLength = encrypted.length - metaLength;
+  const iv = encrypted.slice(65, 65 + 16);
+  const cipherAndIv = encrypted.slice(65, 65 + 16 + cipherTextLength);
+  const ciphertext = cipherAndIv.slice(16);
+  const msgMac = encrypted.slice(65 + 16 + cipherTextLength);
+
+  // check HMAC
+  const px = derive(privateKey, ephemPublicKey);
+  const hash = kdf(px,32);
+  const encryptionKey = hash.slice(0, 16);
+  const macKey = createHash("sha256").update(hash.slice(16)).digest()
+  const dataToMac = Buffer.from(cipherAndIv);
+  const hmacGood = hmacSha256Sign(macKey, dataToMac);
+  assert(hmacGood.equals(msgMac), "Incorrect MAC");
+
+  // decrypt message
+  return aesCtrDecryptLegacy(iv, encryptionKey, ciphertext);
+};
+
+
+// Encrypt AES-128-CTR and serialise as in Parity
+// Using ECDH shared secret KDF
+// Serialization: <ephemPubKey><IV><CipherText><HMAC>
+export const encryptShared = function(privateKeySender, publicKeyRecipient, msg, opts){
+  const sharedPx = derive(privateKeySender, publicKeyRecipient)
+  const sharedPrivateKey = kdf(sharedPx, 32);
+  const sharedPublicKey = getPublic(sharedPrivateKey);
+
+  return encrypt(sharedPublicKey, msg, opts);
+}
+
+// Decrypt serialised AES-128-CTR
+// Using ECDH shared secret KDF
+export const decryptShared = function(privateKeyRecipient, publicKeySender, encrypted) {
+  const sharedPx = derive(privateKeyRecipient, publicKeySender);
+  const sharedPrivateKey = kdf(sharedPx, 32);
+
+  return decrypt(sharedPrivateKey, encrypted);
+}
+
+// @petern was here


### PR DESCRIPTION
Moved message encryption to identity.
`crypto.service.ts` - decode public key to EC point buffer
`identity.service.ts` - added 'encrypt' method
`signing.service.ts` - handle encryption; modified decryption to support both legacy and shared secret encryption.
`index.js` - had to add second chunk to AES, otherwise, decryption wasn't working. Legacy encryption/decryption and AES added to support old messages. Added encryptShared and decryptShared which use ECDH based KDF.