### PR TITLE
Fix access level being set incorrectly in seed flow

### DIFF
--- a/src/app/sign-up/sign-up.component.ts
+++ b/src/app/sign-up/sign-up.component.ts
@@ -88,6 +88,8 @@ export class SignUpComponent implements OnInit, OnDestroy {
       btcDepositAddress,
       network,
     });
+    this.accountService.setAccessLevel(
+      this.publicKeyAdded, this.globalVars.hostname, this.globalVars.accessLevelRequest);
 
     if (!this.globalVars.showJumio()) {
       this.login();


### PR DESCRIPTION
The access level is not being set correctly after an account is added
via the seed flow. This is causing third-party nodes to error when
opening up Jumio after the seed flow.

The error happens because we get a null user returned here:
https://github.com/bitclout/identity/blob/01f13fa46198d6273483f9e8818b63928d911aea/src/app/backend-api.service.ts#L39

The error is caused by the access level check here:
https://github.com/bitclout/identity/blob/b9c367583b1630feb3c70df27fda50600adeeb77/src/app/account.service.ts#L37