### PR TITLE
Changes "update profile" transaction to require Access Level 4

### DIFF
--- a/src/app/identity.service.ts
+++ b/src/app/identity.service.ts
@@ -195,12 +195,12 @@ export class IdentityService {
       case TransactionMetadataCreatorCoinTransfer:
       case TransactionMetadataSwapIdentity:
       case TransactionMetadataUpdateGlobalParams:
+      case TransactionMetadataUpdateProfile:
         return AccessLevel.Full;
 
       case TransactionMetadataFollow:
       case TransactionMetadataPrivateMessage:
       case TransactionMetadataSubmitPost:
-      case TransactionMetadataUpdateProfile:
       case TransactionMetadataLike:
         return AccessLevel.ApproveLarge;
     }


### PR DESCRIPTION
Since the update profile transaction allows the caller to change the Founder Reward percentage, it can be argued that this is a financial transaction. Furthermore, changing a username could be considered one of the most sensitive operations on a platform built around reputation.