### PR TITLE
Add message to identity log in page about free CLOUT.

### DIFF
--- a/src/app/log-in/log-in.component.html
+++ b/src/app/log-in/log-in.component.html
@@ -4,7 +4,7 @@
   <div class="font-weight-bold fs-30px mb-20px">
     Log in to {{ globalVars.hostname }}
     <div class="font-weight-normal fs-15px">
-      New users that sign up with a Google account or seed phrase get {{ globalVars.getFreeCloutMessage() }} free!
+      Sign up with a new Google account or seed phrase and get {{ globalVars.getFreeCloutMessage() }}!
     </div>
   </div>
 

--- a/src/app/log-in/log-in.component.html
+++ b/src/app/log-in/log-in.component.html
@@ -3,8 +3,8 @@
 <div class="container home-container" *ngIf="globalVars.inTab || globalVars.webview">
   <div class="font-weight-bold fs-30px mb-20px">
     Log in to {{ globalVars.hostname }}
-    <div *ngIf="!hasUsers" class="font-weight-normal fs-15px">
-      Sign up with a new Google account or seed phrase and get {{ globalVars.getFreeCloutMessage() }} free!
+    <div class="font-weight-normal fs-15px">
+      New users that sign up with a Google account or seed phrase get {{ globalVars.getFreeCloutMessage() }} free!
     </div>
   </div>
 

--- a/src/app/log-in/log-in.component.html
+++ b/src/app/log-in/log-in.component.html
@@ -3,6 +3,9 @@
 <div class="container home-container" *ngIf="globalVars.inTab || globalVars.webview">
   <div class="font-weight-bold fs-30px mb-20px">
     Log in to {{ globalVars.hostname }}
+    <div *ngIf="!hasUsers" class="font-weight-normal fs-15px">
+      Sign up with a new Google account or seed phrase and get {{ globalVars.getFreeCloutMessage() }} free!
+    </div>
   </div>
 
   <div class="row">


### PR DESCRIPTION
I added a simple message to the first page of identity to tell you the referral amount you will receive upon sign up.  This makes the UX a bit smoother as you go from clicking "Sign Up and Receive $X Free" on the home page to Identity. 

![image](https://user-images.githubusercontent.com/81658108/133333102-b7d5a31a-c478-402c-bc42-efeba042bcb1.png)
